### PR TITLE
Import SQLAlchemyModelFactory in factory init

### DIFF
--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -40,6 +40,7 @@ from .base import (
 
 from .mogo import MogoFactory
 from .django import DjangoModelFactory
+from .alchemy import SQLAlchemyModelFactory
 
 from .declarations import (
     LazyAttribute,


### PR DESCRIPTION
Gives easier access to SQLAlchemyModelFactory and is consistent with Mogo and Django imports.