### PR TITLE
Make safe repr more safe

### DIFF
--- a/factory/utils.py
+++ b/factory/utils.py
@@ -101,7 +101,7 @@ def import_object(module_name, attribute_name):
 def _safe_repr(obj):
     try:
         obj_repr = repr(obj)
-    except:
+    except Exception:
         return '<bad_repr object at %s>' % id(obj)
 
     try:  # Convert to "text type" (= unicode)

--- a/factory/utils.py
+++ b/factory/utils.py
@@ -101,7 +101,7 @@ def import_object(module_name, attribute_name):
 def _safe_repr(obj):
     try:
         obj_repr = repr(obj)
-    except UnicodeError:
+    except:
         return '<bad_repr object at %s>' % id(obj)
 
     try:  # Convert to "text type" (= unicode)


### PR DESCRIPTION
`_safe_repr` is called by debug logging code in factoryboy. It seems to me it'd be ideal not to get errors from this part of the code... yes if `repr(obj)` fails you _may_ have a problem with your `obj`... but I'd rather catch that in the actual tests rather than raised due to an internal feature of factoryboy.

A concrete example: trying to create a Django model instance with a fake id for a foreign key relation (rather than using SubFactory and creating the related instance as well)... it would work except `repr(obj)` calls the model's `__unicode__` method, which in my case accessed the foreign key field and failed, raising a `DoesNotExist` exception.

I think it'd be okay to return the `'bad_repr object'` string if _any_ exception is raised by `repr`.