### PR TITLE
Change package name to 'factory-boy'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ PACKAGE = 'factory'
 
 
 setup(
-    name='factory_boy',
+    name='factory-boy',
     version=get_version(PACKAGE),
     description="A verstile test fixtures replacement based on thoughtbot's factory_girl for Ruby.",
     author='Mark Sandstrom',


### PR DESCRIPTION
Pip doesn't handle packages containing underscores in their names very well. For example `pip freeze` always outputs `factory-boy==2.3.1` even if the package was installed with `pip install factory_boy`.

PyCharm seems somewhat confused by this as well and has some trouble indexing the package correctly.

Also the python community seems to prefer to use dashes in package names instead of underscores.

Hopefully this should give you enough reasons to consider changing the name.