### PR TITLE
Support SelfAttribute in fuzzy

### DIFF
--- a/tests/test_fuzzy.py
+++ b/tests/test_fuzzy.py
@@ -19,13 +19,14 @@
 # LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
-
-
 import datetime
 import decimal
+import collections
 
 from factory import compat
 from factory import fuzzy
+from factory import base
+from factory import declarations
 
 from .compat import mock, unittest
 from . import utils
@@ -74,6 +75,23 @@ class FuzzyChoiceTestCase(unittest.TestCase):
         res = d.evaluate(2, None, False)
         self.assertIn(res, [0, 1, 2])
 
+    def test_lazy(self):
+        options = [1, 2, 3]
+        fake_choice = lambda d: sum(d)
+
+        fuzz = fuzzy.FuzzyChoice(choices=declarations.SelfAttribute('choices'))
+
+        class FooFactory(base.Factory):
+            FACTORY_FOR = collections.namedtuple(
+                'Foo', 'choices')
+
+            choices = options
+
+        with mock.patch('random.choice', fake_choice):
+            res = fuzz.evaluate(2, FooFactory(), False)
+
+        self.assertEqual(6, res)
+
 
 class FuzzyIntegerTestCase(unittest.TestCase):
     def test_definition(self):
@@ -115,6 +133,26 @@ class FuzzyIntegerTestCase(unittest.TestCase):
 
         with mock.patch('random.randrange', fake_randrange):
             res = fuzz.evaluate(2, None, False)
+
+        self.assertEqual((5 + 8 + 1) * 3, res)
+
+    def test_lazy(self):
+        fake_randrange = lambda low, high, step: (low + high) * step
+
+        fuzz = fuzzy.FuzzyInteger(low=declarations.SelfAttribute('low'),
+                                  high=declarations.SelfAttribute('high'),
+                                  step=declarations.SelfAttribute('step'))
+
+        class FooFactory(base.Factory):
+            FACTORY_FOR = collections.namedtuple(
+                'Foo', 'low high step')
+
+            low = 5
+            high = 8
+            step = 3
+
+        with mock.patch('random.randrange', fake_randrange):
+            res = fuzz.evaluate(2, FooFactory(), False)
 
         self.assertEqual((5 + 8 + 1) * 3, res)
 
@@ -171,6 +209,27 @@ class FuzzyDecimalTestCase(unittest.TestCase):
 
         self.assertEqual(decimal.Decimal('8.001').quantize(decimal.Decimal(10) ** -3), res)
 
+    def test_lazy(self):
+        fake_uniform = lambda low, high: low + high + 0.001
+
+        fuzz = fuzzy.FuzzyDecimal(
+            low=declarations.SelfAttribute('low'),
+            high=declarations.SelfAttribute('high'),
+            precision=declarations.SelfAttribute('precision'))
+
+        class FooFactory(base.Factory):
+            FACTORY_FOR = collections.namedtuple(
+                'Foo', 'low high precision')
+
+            low = 0.0
+            high = 8.0
+            precision = 3
+
+        with mock.patch('random.uniform', fake_uniform):
+            res = fuzz.evaluate(2, FooFactory(), False)
+
+        self.assertEqual(decimal.Decimal('8.001').quantize(decimal.Decimal(10) ** -3), res)
+
 
 class FuzzyDateTestCase(unittest.TestCase):
     @classmethod
@@ -200,13 +259,13 @@ class FuzzyDateTestCase(unittest.TestCase):
             self.assertLessEqual(res, self.jan3)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyDate,
-            self.jan31, self.jan1)
+        fuzz = fuzzy.FuzzyDate(self.jan31, self.jan1)
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_invalid_partial_definition(self):
         with utils.mocked_date_today(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyDate,
-                self.jan31)
+            fuzz = fuzzy.FuzzyDate(self.jan31)
+            self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_biased(self):
         """Tests a FuzzyDate with a biased random.randint."""
@@ -260,13 +319,15 @@ class FuzzyNaiveDateTimeTestCase(unittest.TestCase):
 
     def test_aware_start(self):
         """Tests that a timezone-aware start datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
+        fuzz = fuzzy.FuzzyNaiveDateTime(
             self.jan1.replace(tzinfo=compat.UTC), self.jan31)
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_aware_end(self):
         """Tests that a timezone-aware end datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
+        fuzz = fuzzy.FuzzyNaiveDateTime(
             self.jan1, self.jan31.replace(tzinfo=compat.UTC))
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_force_year(self):
         fuzz = fuzzy.FuzzyNaiveDateTime(self.jan1, self.jan31, force_year=4)
@@ -318,13 +379,13 @@ class FuzzyNaiveDateTimeTestCase(unittest.TestCase):
             self.assertEqual(4, res.microsecond)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-            self.jan31, self.jan1)
+        fuzz = fuzzy.FuzzyNaiveDateTime(self.jan31, self.jan1)
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_invalid_partial_definition(self):
         with utils.mocked_datetime_now(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyNaiveDateTime,
-                self.jan31)
+            fuzz = fuzzy.FuzzyNaiveDateTime(self.jan31)
+            self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_biased(self):
         """Tests a FuzzyDate with a biased random.randint."""
@@ -377,23 +438,23 @@ class FuzzyDateTimeTestCase(unittest.TestCase):
             self.assertLessEqual(res, self.jan3)
 
     def test_invalid_definition(self):
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan31, self.jan1)
+        fuzz = fuzzy.FuzzyDateTime(self.jan31, self.jan1)
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_invalid_partial_definition(self):
         with utils.mocked_datetime_now(self.jan1, fuzzy):
-            self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-                self.jan31)
+            fuzz = fuzzy.FuzzyDateTime(self.jan31)
+            self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_naive_start(self):
         """Tests that a timezone-naive start datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan1.replace(tzinfo=None), self.jan31)
+        fuzz = fuzzy.FuzzyDateTime(self.jan1.replace(tzinfo=None), self.jan31)
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_naive_end(self):
         """Tests that a timezone-naive end datetime is rejected."""
-        self.assertRaises(ValueError, fuzzy.FuzzyDateTime,
-            self.jan1, self.jan31.replace(tzinfo=None))
+        fuzz = fuzzy.FuzzyDateTime(self.jan1, self.jan31.replace(tzinfo=None))
+        self.assertRaises(ValueError, fuzz.fuzz)
 
     def test_force_year(self):
         fuzz = fuzzy.FuzzyDateTime(self.jan1, self.jan31, force_year=4)
@@ -466,6 +527,50 @@ class FuzzyDateTimeTestCase(unittest.TestCase):
 
         self.assertEqual(datetime.datetime(2013, 1, 2, tzinfo=compat.UTC), res)
 
+    def test_lazy(self):
+        start_date = datetime.datetime(2013, 1, 1, tzinfo=compat.UTC)
+        end_date = datetime.datetime(2013, 1, 10, tzinfo=compat.UTC)
+
+        class FooFactory(base.Factory):
+            FACTORY_FOR = collections.namedtuple(
+                'Foo', 'start_dt end_dt force_year force_month force_day '
+                       'force_hour force_minute force_second '
+                       'force_microsecond')
+
+            start_dt = start_date
+            end_dt = end_date
+            force_year = 2013
+            force_month = 1
+            force_day = 2
+            force_hour = 11
+            force_minute = 22
+            force_second = 33
+            force_microsecond = 44
+
+        fuzz = fuzzy.FuzzyDateTime(
+            start_dt=datetime.datetime.now(tz=compat.UTC),
+            force_year=declarations.SelfAttribute('force_year'),
+            force_month=declarations.SelfAttribute('force_month'),
+            force_day=declarations.SelfAttribute('force_day'),
+            force_hour=declarations.SelfAttribute('force_hour'),
+            force_minute=declarations.SelfAttribute('force_minute'),
+            force_second=declarations.SelfAttribute('force_second'),
+            force_microsecond=declarations.SelfAttribute('force_microsecond'))
+
+        res = fuzz.evaluate(2, FooFactory(), False)
+
+        self.assertEqual(datetime.datetime(2013, 1, 2, 11, 22, 33, 44,
+                                           tzinfo=compat.UTC), res)
+
+        fuzz = fuzzy.FuzzyDateTime(
+            start_dt=declarations.SelfAttribute('start_dt'),
+            end_dt=declarations.SelfAttribute('end_dt'))
+
+        res = fuzz.evaluate(2, FooFactory(), False)
+
+        self.assertLessEqual(start_date, res)
+        self.assertGreaterEqual(end_date, res)
+
 
 class FuzzyTextTestCase(unittest.TestCase):
 
@@ -504,3 +609,88 @@ class FuzzyTextTestCase(unittest.TestCase):
 
         for char in res:
             self.assertIn(char, ['a', 'b', 'c'])
+
+    def test_lazy(self):
+        chars = ['a', 'b', 'c']
+
+        fuzz = fuzzy.FuzzyText(prefix=declarations.SelfAttribute('prefix'),
+                               suffix=declarations.SelfAttribute('suffix'),
+                               chars=declarations.SelfAttribute('chars_'),
+                               length=declarations.SelfAttribute('length'))
+
+        class FooFactory(base.Factory):
+            FACTORY_FOR = collections.namedtuple(
+                'Foo', 'prefix suffix chars_ length')
+
+            prefix = 'pre'
+            suffix = 'post'
+            chars_ = chars
+            length = 12
+
+        res = fuzz.evaluate(2, FooFactory(), False)
+
+        self.assertEqual('pre', res[:3])
+        self.assertEqual('post', res[-4:])
+        self.assertEqual(3 + 12 + 4, len(res))
+
+        for char in res[3:-4]:
+            self.assertIn(char, chars)
+
+
+class LazyArgumentTestCase(unittest.TestCase):
+    def setUp(self):
+        class Foo(object):
+            param1 = fuzzy.LazyArgument()
+            param2 = fuzzy.LazyArgument()
+
+        self.foo = Foo()
+
+    def test_literal(self):
+        self.foo.param1 = 123
+        self.foo.param2 = 'test'
+
+        self.assertEqual(self.foo.param1, 123)
+        self.assertEqual(self.foo.param2, 'test')
+
+    def test_evaluate(self):
+        self.foo.param1 = declarations.SelfAttribute('f1')
+        self.foo.param2 = declarations.SelfAttribute('f2')
+
+        Bar = collections.namedtuple('Bar', 'f1 f2')
+
+        with fuzzy.LazyArgument.evaluate(2, Bar('val1', 14), False):
+            self.assertEqual(self.foo.param1, 'val1')
+            self.assertEqual(self.foo.param2, 14)
+
+        self.assertIsInstance(self.foo.param1, declarations.SelfAttribute)
+        self.assertIsInstance(self.foo.param2, declarations.SelfAttribute)
+
+        with fuzzy.LazyArgument.evaluate(2, Bar(1.1, {"a": 2}), False):
+            self.assertEqual(self.foo.param1, 1.1)
+            self.assertEqual(self.foo.param2, {"a": 2})
+
+    def test_factory(self):
+        Bar = collections.namedtuple(
+            'Bar', 'start_date end_date lower_limit upper_limit value')
+
+        class BarFactory(base.Factory):
+            FACTORY_FOR = Bar
+
+            start_date = fuzzy.FuzzyDate(datetime.date(2014, 1, 1))
+            end_date = fuzzy.FuzzyDate(
+                declarations.SelfAttribute('start_date'))
+
+            lower_limit = fuzzy.FuzzyInteger(100)
+            upper_limit = fuzzy.FuzzyInteger(
+                declarations.SelfAttribute('lower_limit'), 200)
+            value = fuzzy.FuzzyInteger(
+                declarations.SelfAttribute('lower_limit'),
+                declarations.SelfAttribute('upper_limit'))
+
+
+        bar = BarFactory()
+
+        self.assertGreaterEqual(bar.end_date, bar.start_date)
+        self.assertGreaterEqual(bar.upper_limit, bar.lower_limit)
+        self.assertGreaterEqual(bar.value, bar.lower_limit)
+        self.assertLessEqual(bar.value, bar.upper_limit)


### PR DESCRIPTION
Hello.

I suggest to add support of SelfAttribute in all fuzzy fields. It can by useful for dependent fields. For example:

    class FooFactory(Factory):
        start_date = fuzzy.FuzzyDate(date(2014, 1, 1))
        end_date = fuzzy.FuzzyDate(SelfAttribute('start_date'))