### PR TITLE
Correcting syntax in batch-create example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -155,11 +155,11 @@ No matter which strategy is used, it's possible to override the defined attribut
     "Joe"
 
 
-It is also possible to create a bunch of objects in a single call:
+It is also possible to create a bunch of objects in a single call with the ``*_batch()`` variants:
 
 .. code-block:: pycon
 
-    >>> users = UserFactory.build(10, first_name="Joe")
+    >>> users = UserFactory.build_batch(10, first_name="Joe")
     >>> len(users)
     10
     >>> [user.first_name for user in users]


### PR DESCRIPTION
This confused me! Props to @armirusco for pointing out the correct syntax to me.
