### PR TITLE
replace build method with build_batch in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ It is also possible to create a bunch of objects in a single call:
 
 .. code-block:: pycon
 
-    >>> users = UserFactory.build(10, first_name="Joe")
+    >>> users = UserFactory.build_batch(10, first_name="Joe")
     >>> len(users)
     10
     >>> [user.first_name for user in users]


### PR DESCRIPTION
I'm not sure if creating a list of instances with the method `build` is still supported. I couldn't make it work and replaced `build` with `build_batch` in my code. So I thought it could be outdated.