### PR TITLE
avoid NoneType is not iterable error

### DIFF
--- a/factory/base.py
+++ b/factory/base.py
@@ -435,7 +435,8 @@ class BaseFactory(object):
                 retrieved DeclarationDict.
         """
         decls = cls._meta.declarations.copy()
-        decls.update(extra_defs)
+        if extra_defs is not None:
+            decls.update(extra_defs)
         return decls
 
     @classmethod


### PR DESCRIPTION
I encountered this while working on some custom factory classes

`extra_defs` kwarg default value is `None` but currently the function breaks if it gets a `None` value 