### PR TITLE
Update README.rst: use build_batch instead of build for creating multiple objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,7 +159,7 @@ It is also possible to create a bunch of objects in a single call:
 
 .. code-block:: pycon
 
-    >>> users = UserFactory.build(10, first_name="Joe")
+    >>> users = UserFactory.build_batch(10, first_name="Joe")
     >>> len(users)
     10
     >>> [user.first_name for user in users]


### PR DESCRIPTION
Fix command for building batch objects