### PR TITLE
Removed deprecation warning for django factories

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -31,6 +31,7 @@ import functools
 
 """factory_boy extensions for use with the Django framework."""
 
+import django
 try:
     from django.core import files as django_files
 except ImportError as e:  # pragma: no cover
@@ -92,8 +93,12 @@ class DjangoModelFactory(base.Factory):
 
         if is_string(definition) and '.' in definition:
             app, model = definition.split('.', 1)
-            from django.db.models import loading as django_loading
-            return django_loading.get_model(app, model)
+            if django.VERSION >= (1, 7, 0):
+                from django.apps import apps as django_apps
+                get_model = django_apps.get_model
+            else:
+                from django.db.models.loading import get_model
+            return get_model(app, model)
 
         return definition
 


### PR DESCRIPTION
Django 1.7 introduced the [app registry API](https://docs.djangoproject.com/en/1.7/ref/applications/#application-registry), we should use this instead of django.db.models.loading : the latter will be [removed in Django 1.9](http://django.readthedocs.org/en/latest/internals/deprecation.html#deprecation-removed-in-1-9).

PS: Not sure about the code style.