### PR TITLE
Fix tox.ini config to mimic .travis.yml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,17 +1,16 @@
 [tox]
-envlist = py26,py27,pypy
+envlist = py27,py34,pypy
 
 [testenv]
 commands=
     python -W default setup.py test
 
-[testenv:py26]
+[testenv:py27]
 
 deps=
     mock
-    unittest2
 
-[textenv:py27]
+[testenv:pypy]
 
 deps=
     mock


### PR DESCRIPTION
Without mock installed it was `ImportError: No module named mock` for py27