### PR TITLE
Remove requirement.txt, move content into requirements.txt

### DIFF
--- a/requirement.txt
+++ b/requirement.txt
@@ -1,1 +1,0 @@
-fake-factory>=0.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+fake-factory>=0.5.0


### PR DESCRIPTION
requirement.txt was introduced in 6f37f9b, after requirements.txt
had already put in place. dev_requirements.txt installs the contents
of requirements.txt (which is empty) while a single dependency is
specified in requirement.txt. It looks like requirement.txt was added
accidently and it's content should always have been in requirements.txt.

This removes requirement.txt and puts the dependency delcared in there
in requirements.txt.