### PR TITLE
Fix mute_signals behavior for signals with caching

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -277,6 +277,8 @@ class mute_signals(object):
                          receivers)
 
             signal.receivers = receivers
+            with signal.lock:
+                signal.sender_receivers_cache.clear()
         self.paused = {}
 
     def copy(self):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -678,6 +678,19 @@ class PreventSignalsTestCase(unittest.TestCase):
 
         self.assertSignalsReactivated()
 
+    def test_signal_cache(self):
+        with factory.django.mute_signals(signals.pre_save, signals.post_save):
+            signals.post_save.connect(self.handlers.mute_block_receiver)
+            WithSignalsFactory()
+
+        self.assertTrue(self.handlers.mute_block_receiver.call_count, 1)
+        self.assertEqual(self.handlers.pre_init.call_count, 1)
+        self.assertFalse(self.handlers.pre_save.called)
+        self.assertFalse(self.handlers.post_save.called)
+
+        self.assertSignalsReactivated()
+        self.assertTrue(self.handlers.mute_block_receiver.call_count, 1)
+
     def test_class_decorator(self):
         @factory.django.mute_signals(signals.pre_save, signals.post_save)
         class WithSignalsDecoratedFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
Connecting signals (with use_caching=True) inside mute_signals
was breaking unmute on exit. Paused receivers were not running.
This was caused by signal cache not being restored after unpatching.
Workaround is to clear signal cache on exit.

Problem was discovered when using django-dirtyfields,
which attaches post_save receiver in model init.

Alternative solution might be disabling connecting/disconnecting
muted signals inside `mute_signals`. What do you think?

Fixes #212 