### PR TITLE
Support Faker provider positional args

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -57,8 +57,9 @@ class Faker(declarations.OrderedDeclaration):
     Usage:
         >>> foo = factory.Faker('name')
     """
-    def __init__(self, provider, locale=None, **kwargs):
+    def __init__(self, provider, locale=None, *args, **kwargs):
         self.provider = provider
+        self.provider_args = args
         self.provider_kwargs = kwargs
         self.locale = locale
 
@@ -66,8 +67,10 @@ class Faker(declarations.OrderedDeclaration):
         kwargs = {}
         kwargs.update(self.provider_kwargs)
         kwargs.update(extra_kwargs)
+
         faker = self._get_faker(self.locale)
-        return faker.format(self.provider, **kwargs)
+
+        return faker.format(self.provider, *self.provider_args, **kwargs)
 
     def evaluate(self, sequence, obj, create, extra=None, containers=()):
         return self.generate(extra or {})

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -112,12 +112,12 @@ class FakerTests(unittest.TestCase):
 
         class BookFactory(factory.Factory):
             title = factory.Faker('bs')
-            bookmarked_pages = factory.Faker('pylist', 10, False, int, locale=None)
+            bookmarked_pages = factory.Faker('pylist', 'en_us', 6, False, int)
 
             class Meta:
                 model = Book
 
         book = BookFactory()
 
-        self.assertEqual(10, len(book.bookmarked_pages))
+        self.assertEqual(6, len(book.bookmarked_pages))
         self.assertTrue(all([isinstance(element, int) for element in book.bookmarked_pages]))

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -103,3 +103,21 @@ class FakerTests(unittest.TestCase):
         self.assertEqual("John", profile.first_name)
         self.assertEqual("Valjean", profile.last_name)
 
+    def test_provider_positional_arguments(self):
+
+        class Book(object):
+            def __init__(self, title, bookmarked_pages):
+                self.title = title
+                self.bookmarked_pages = bookmarked_pages
+
+        class BookFactory(factory.Factory):
+            title = factory.Faker('bs')
+            bookmarked_pages = factory.Faker('pylist', 10, False, int, locale=None)
+
+            class Meta:
+                model = Book
+
+        book = BookFactory()
+
+        self.assertEqual(10, len(book.bookmarked_pages))
+        self.assertTrue(all([isinstance(element, int) for element in book.bookmarked_pages]))


### PR DESCRIPTION
Adds ability to pass positional arguments to the underlying Fake-Factory provider.

This is necessary for some providers which use variable length positional arguments (ex, pylist for it's element types).  

Addresses issue #216 