### PR TITLE
add a way to add custom providers to Faker

### DIFF
--- a/factory/faker.py
+++ b/factory/faker.py
@@ -94,3 +94,8 @@ class Faker(declarations.OrderedDeclaration):
             cls._FAKER_REGISTRY[locale] = faker.Faker(locale=locale)
 
         return cls._FAKER_REGISTRY[locale]
+
+    @classmethod
+    def add_provider(cls, provider, locale=None):
+        """Add a new Faker provider for the specified locale"""
+        cls._get_faker(locale).add_provider(provider)

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -21,8 +21,11 @@
 # THE SOFTWARE.
 
 
-import factory
 import unittest
+
+import faker.providers
+
+import factory
 
 
 class MockFaker(object):
@@ -103,3 +106,30 @@ class FakerTests(unittest.TestCase):
         self.assertEqual("John", profile.first_name)
         self.assertEqual("Valjean", profile.last_name)
 
+    def test_add_provider(self):
+        class Face(object):
+            def __init__(self, smiley, french_smiley):
+                self.smiley = smiley
+                self.french_smiley = french_smiley
+
+        class FaceFactory(factory.Factory):
+            class Meta:
+                model = Face
+
+            smiley = factory.Faker('smiley')
+            french_smiley = factory.Faker('smiley', locale='fr_FR')
+
+        class SmileyProvider(faker.providers.BaseProvider):
+            def smiley(self):
+                return ':)'
+
+        class FrenchSmileyProvider(faker.providers.BaseProvider):
+            def smiley(self):
+                return '(:'
+
+        factory.Faker.add_provider(SmileyProvider)
+        factory.Faker.add_provider(FrenchSmileyProvider, 'fr_FR')
+
+        face = FaceFactory()
+        self.assertEqual(":)", face.smiley)
+        self.assertEqual("(:", face.french_smiley)


### PR DESCRIPTION
factory_boy wraps faker and it stores Faker generators in a 'private'
_FAKER_REGISTRY class attribute dict. There needs to be a way to extend
the Faker generators with additional custom providers (without having to
access _FAKER_REGISTRY directly).

This commit adds a (factory_boy) Faker.add_provider class method which calls Faker's
own `add_provider` method on internally stored (via _FAKER_REGISTRY)
Faker generators.