### PR TITLE
Remove note on Django ForeignKeys with SubFactory

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -40,14 +40,6 @@ All factories for a Django :class:`~django.db.models.Model` should use the
       once all post-generation hooks have run.
 
 
-.. note:: Starting with Django 1.8, it is no longer possible to call ``.build()``
-          on a factory if this factory uses a :class:`~factory.SubFactory` pointing
-          to another model: Django refuses to set a :class:`~djang.db.models.ForeignKey`
-          to an unsaved :class:`~django.db.models.Model` instance.
-
-          See https://code.djangoproject.com/ticket/10811 for details.
-
-
 .. class:: DjangoOptions(factory.base.FactoryOptions)
 
     The ``class Meta`` on a :class:`~DjangoModelFactory` supports extra parameters:


### PR DESCRIPTION
The note is no longer correct since Django 1.8.4 which reverted that change:
https://code.djangoproject.com/ticket/25160