### PR TITLE
Break if raise StopIteration

### DIFF
--- a/factory/utils.py
+++ b/factory/utils.py
@@ -148,9 +148,12 @@ class ResetableIterator(object):
             if self.next_elements:
                 yield self.next_elements.popleft()
             else:
-                value = next(self.iterator)
-                self.past_elements.append(value)
-                yield value
+                try:
+                    value = next(self.iterator)
+                    self.past_elements.append(value)
+                    yield value
+                except StopIteration as e:
+                    break
 
     def reset(self):
         self.next_elements.clear()


### PR DESCRIPTION
In my project I get the exception "StopIteration" when Travis run the tests.

```
Traceback (most recent call last):
  File "/home/travis/build/PlatziDev/Platzi/django/jobboard/tests.py", line 222, in setUp
    self.joboffer = JobOfferFactory.create(organization=self.es_org, published=True)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 558, in create
    attrs = cls.attributes(create=True, extra=kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 400, in attributes
    force_sequence=force_sequence,
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 228, in build
    return stub.__fill__()
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 83, in __fill__
    res[attr] = getattr(self, attr)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 105, in __getattr__
    val = val.evaluate(self, self.__containers)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 160, in evaluate
    containers=containers,
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/declarations.py", line 298, in evaluate
    return self.generate(sequence, obj, create, defaults)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/declarations.py", line 385, in generate
    return subfactory.simple_generate(create, **params)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 645, in simple_generate
    return cls.generate(strategy, **kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 612, in generate
    return action(**kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 558, in create
    attrs = cls.attributes(create=True, extra=kwargs)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/base.py", line 400, in attributes
    force_sequence=force_sequence,
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 228, in build
    return stub.__fill__()
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 83, in __fill__
    res[attr] = getattr(self, attr)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 105, in __getattr__
    val = val.evaluate(self, self.__containers)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/containers.py", line 160, in evaluate
    containers=containers,
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/declarations.py", line 170, in evaluate
    value = next(iter(self.iterator))
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/factory/utils.py", line 137, in __iter__
    value = next(self.iterator)
StopIteration
```