### PR TITLE
Fix: call django.setup() before loading a model

### DIFF
--- a/factory/django.py
+++ b/factory/django.py
@@ -81,6 +81,7 @@ def _lazy_load_get_model():
         from django.db.models.loading import get_model
 
     else:
+        django.setup()
         from django import apps as django_apps
         get_model = django_apps.apps.get_model
     _LAZY_LOADS['get_model'] = get_model


### PR DESCRIPTION
This is the simplest way I found to fix #160 in cases where
a test runner does not explicitly call django.setup priot to
test discovery.

This is also [the documented method](https://docs.djangoproject.com/en/1.8/ref/applications/#django.setup) for python scripts that hook into django apps.