### PR TITLE
Remove unneeded 'import factory.alchemy'

### DIFF
--- a/examples/flask_alchemy/demoapp_factories.py
+++ b/examples/flask_alchemy/demoapp_factories.py
@@ -1,5 +1,4 @@
 import factory
-import factory.alchemy
 import factory.fuzzy
 
 import demoapp


### PR DESCRIPTION
'import factory.alchemy' is no longer needed because of this commit: https://github.com/rbarrois/factory_boy/commit/9246fa6d26ca655c02ae37bbfc389d9f34dfba16