### PR TITLE
Make Faker.generate accept regular kwargs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,14 @@
 ChangeLog
 =========
 
+.. _v2.6.2:
+
+2.6.2 (TBD)
+------------------
+*Refactoring:*
+
+    - Refactor :meth:`factory.faker.Faker.generate` so it can be called with no arguments. The behaviour is the same as when calling with an empty dict.
+
 .. _v2.6.1:
 
 2.6.1 (2016-02-10)

--- a/factory/faker.py
+++ b/factory/faker.py
@@ -62,15 +62,15 @@ class Faker(declarations.OrderedDeclaration):
         self.provider_kwargs = kwargs
         self.locale = locale
 
-    def generate(self, extra_kwargs):
+    def generate(self, **extra_kwargs):
         kwargs = {}
         kwargs.update(self.provider_kwargs)
-        kwargs.update(extra_kwargs)
+        kwargs.update(**extra_kwargs)
         faker = self._get_faker(self.locale)
         return faker.format(self.provider, **kwargs)
 
-    def evaluate(self, sequence, obj, create, extra=None, containers=()):
-        return self.generate(extra or {})
+    def evaluate(self, sequence, obj, create, extra=(), containers=()):
+        return self.generate(**extra)
 
     _FAKER_REGISTRY = {}
     _DEFAULT_LOCALE = faker.config.DEFAULT_LOCALE

--- a/tests/test_faker.py
+++ b/tests/test_faker.py
@@ -52,7 +52,26 @@ class FakerTests(unittest.TestCase):
     def test_simple_biased(self):
         self._setup_mock_faker(name="John Doe")
         faker_field = factory.Faker('name')
-        self.assertEqual("John Doe", faker_field.generate({}))
+        self.assertEqual("John Doe", faker_field.generate())
+
+    def test_calling_generate_with_extra_kwargs(self):
+        class StringId(object):
+            def __init__(self, string_id):
+                self.string_id = string_id
+
+        class StringIdFactory(factory.Factory):
+            class Meta:
+                model = StringId
+
+            string_id = factory.Sequence(
+                lambda n: str(
+                    factory.Faker('random_int', min=1).generate(max=100)))
+
+        string_id = StringIdFactory()
+
+        self.assertIsInstance(string_id.string_id, str)
+        self.assertLess(0, int(string_id.string_id))
+        self.assertGreater(101, int(string_id.string_id))
 
     def test_full_factory(self):
         class Profile(object):


### PR DESCRIPTION
Use the normal python idiom for passing kwargs rather than passing in a
dict. This makes the API nicer and allows calling `generate` without any
arguments.