### PR TITLE
Clarify sequence behavior on inheritance

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -711,8 +711,9 @@ The sequence counter is shared across all :class:`Sequence` attributes of the
 Inheritance
 ~~~~~~~~~~~
 
-When a :class:`Factory` inherits from another :class:`Factory`, their
-sequence counter is shared:
+When a :class:`Factory` inherits from another :class:`Factory` and the `model`
+of the subclass inherits from the `model` of the parent, the sequence counter
+is shared across the :class:`Factory` classes:
 
 .. code-block:: python
 


### PR DESCRIPTION
Sequences are only shared via inheritance if the model of the subclass is the same as or a subclass of the model of the parent class. Clarify the docs on this point.