### PR TITLE
Don't leave AttributeBuilder in an inconsistent state on exceptions

### DIFF
--- a/factory/containers.py
+++ b/factory/containers.py
@@ -102,8 +102,10 @@ class LazyStub(object):
             val = self.__attrs[name]
             if isinstance(val, LazyValue):
                 self.__pending.append(name)
-                val = val.evaluate(self, self.__containers)
-                last = self.__pending.pop()
+                try:
+                    val = val.evaluate(self, self.__containers)
+                finally:
+                    last = self.__pending.pop()
                 assert name == last
             self.__values[name] = val
             return val


### PR DESCRIPTION
When one of the LazyValues raises an exception, don't leave its name in __pending stack of the AttributeBuilder, preventing evaluation of any other LazyValues.

The use case for this is: several declarations on a factory have to be in sync with each other, but can supply default values if needed. For example:

```python
class UserFactory(factory.Factory):
    @factory.lazy_attribute
    def username(self):
        return self.email[:self.email.index('@')]

    @factory.lazy_attribute
    def email(self):
        try:
            return self.username + '@example.com'
        except factory.containers.CyclicDefinitionError:
            return 'dummy@example.com'
````

This allows any of the following:

```python
UserFactory(username='jane')
UserFactory(email='jane@somewhere.com')
UserFactory()
```