### PR TITLE
optional forced flush on SQLAlchemyModelFactory

### DIFF
--- a/docs/orms.rst
+++ b/docs/orms.rst
@@ -333,6 +333,10 @@ To work, this class needs an `SQLAlchemy`_ session object affected to the :attr:
         SQLAlchemy session to use to communicate with the database when creating
         an object through this :class:`SQLAlchemyModelFactory`.
 
+    .. attribute:: force_flush
+
+        Force a session flush() at the end of :func:`~factory.alchemy.SQLAlchemyModelFactory._create()`.
+
 A (very) simple example:
 
 .. code-block:: python

--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -27,6 +27,7 @@ class SQLAlchemyOptions(base.FactoryOptions):
     def _build_default_options(self):
         return super(SQLAlchemyOptions, self)._build_default_options() + [
             base.OptionDefault('sqlalchemy_session', None, inherit=True),
+            base.OptionDefault('force_flush', False, inherit=True),
         ]
 
 
@@ -43,4 +44,6 @@ class SQLAlchemyModelFactory(base.Factory):
         session = cls._meta.sqlalchemy_session
         obj = model_class(*args, **kwargs)
         session.add(obj)
+        if cls._meta.force_flush:
+            session.flush()
         return obj


### PR DESCRIPTION
fixes rbarrois/factory_boy#81

Should allow the user to force a session flush after each model gets created for different scenarios described in #81 by defining force_flush = True in the Meta of the SQLAlchemy Factory implementation.