### PR TITLE
Stop advertising factory_boy supports Python 2.6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Links
 * Package: https://pypi.python.org/pypi/factory_boy/
 * Mailing-list: `factoryboy@googlegroups.com <mailto:factoryboy@googlegroups.com>`_ | https://groups.google.com/forum/#!forum/factoryboy
 
-factory_boy supports Python 2.6, 2.7, 3.2 to 3.5, as well as PyPy; it requires only the standard Python library.
+factory_boy supports Python 2.7, 3.2 to 3.5, as well as PyPy; it requires only the standard Python library.
 
 
 Download

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.6",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.2",


### PR DESCRIPTION
Support was already gone with literal sets.

Follows up issue #268 