### PR TITLE
Add documentation and test for subfactory using "factory_parent" attribute

### DIFF
--- a/docs/recipes.rst
+++ b/docs/recipes.rst
@@ -327,7 +327,21 @@ Here, we want:
         country = factory.SubFactory(CountryFactory)
         owner = factory.SubFactory(UserFactory, country=factory.SelfAttribute('..country'))
 
+If the value of a field on the child factory is indirectly derived from a field on the parent factory, you will need to use LazyAttribute and poke the "factory_parent" attribute.
 
+This time, we want the company owner to live in a country neighboring the country of the company:
+
+.. code-block:: python
+
+    class CompanyFactory(factory.django.DjangoModelFactory):
+        class Meta:
+            model = models.Company
+
+        name = "ACME, Inc."
+        country = factory.SubFactory(CountryFactory)
+        owner = factory.SubFactory(UserFactory,
+            country=factory.LazyAttribute(lambda o: get_random_neighbor(o.factory_parent.country)))
+ 
 Custom manager methods
 ----------------------
 

--- a/tests/test_using.py
+++ b/tests/test_using.py
@@ -1268,6 +1268,26 @@ class SubFactoryTestCase(unittest.TestCase):
         self.assertEqual('x0x', test_model.two.one)
         self.assertEqual('x0xx0x', test_model.two.two)
 
+    def test_sub_factory_with_lazy_fields_access_factory_parent(self):
+        class TestModel2(FakeModel):
+            pass
+
+        class TestModelFactory(FakeModelFactory):
+            class Meta:
+                model = TestModel
+            one = 3
+
+        class TestModel2Factory(FakeModelFactory):
+            class Meta:
+                model = TestModel2
+            one = 'parent'
+            child = factory.SubFactory(TestModelFactory,
+                one=factory.LazyAttribute(lambda o: '%s child' % o.factory_parent.one),
+            )
+
+        test_model = TestModel2Factory()
+        self.assertEqual('parent child', test_model.child.one)
+
     def test_sub_factory_and_sequence(self):
         class TestObject(object):
             def __init__(self, **kwargs):


### PR DESCRIPTION
Add documentation on how to use a LazyAttribute in a SubFactory and poke the "factory_parent" attribute to indirectly derive the value of a field on the child factory from a field on the parent factory. This commit adds an example to recipes that explains how it can be done. It also adds a test to make sure that this feature continues to work as is now described in the documentation.