### PR TITLE
Sqlalchemy session handling

### DIFF
--- a/factory/alchemy.py
+++ b/factory/alchemy.py
@@ -59,7 +59,11 @@ class SQLAlchemyModelFactory(base.Factory):
         session_persistence = cls._meta.sqlalchemy_session_persistence
         if cls._meta.force_flush:
             session_persistence = SESSION_PERSISTENCE_FLUSH
-            warnings.warn("force_flush has been deprecated as of 2.8.0 and will be removed in 3.0.0. Please use `sqlalchemy_session_persistence='flush'` insead.", DeprecationWarning)
+            warnings.warn(
+                "force_flush has been deprecated as of 2.8.0 and will be removed in 3.0.0." \
+                "lease use `sqlalchemy_session_persistence='flush'` insead.",
+                DeprecationWarning,
+            )
         if session_persistence not in VALID_SESSION_PERSISTENCE_TYPES:
             raise TypeError(
                 "'sqlalchemy_session_persistence' must be 'flush' or 'commit', got '%s'"
@@ -68,8 +72,8 @@ class SQLAlchemyModelFactory(base.Factory):
 
         obj = model_class(*args, **kwargs)
         session.add(obj)
-        if session_persistence == 'flush':
+        if session_persistence == SESSION_PERSISTENCE_FLUSH:
             session.flush()
-        elif session_persistence == 'commit':
+        elif session_persistence == SESSION_PERSISTENCE_COMMIT:
             session.commit()
         return obj

--- a/factory/base.py
+++ b/factory/base.py
@@ -129,10 +129,21 @@ class BaseMeta:
 
 
 class OptionDefault(object):
-    def __init__(self, name, value, inherit=False):
+    """The default for an option.
+
+    Attributes:
+        name: str, the name of the option ('class Meta' attribute)
+        value: object, the default value for the option
+        inherit: bool, whether to inherit the value from the parent factory's `class Meta`
+            when no value is provided
+        checker: callable or None, an optional function used to detect invalid option
+            values at declaration time
+    """
+    def __init__(self, name, value, inherit=False, checker=None):
         self.name = name
         self.value = value
         self.inherit = inherit
+        self.checker = checker
 
     def apply(self, meta, base_meta):
         value = self.value
@@ -140,6 +151,10 @@ class OptionDefault(object):
             value = getattr(base_meta, self.name, value)
         if meta is not None:
             value = getattr(meta, self.name, value)
+
+        if self.checker is not None:
+            self.checker(meta, value)
+
         return value
 
     def __str__(self):

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -56,7 +56,7 @@ class StandardFactory(SQLAlchemyModelFactory):
     foo = factory.Sequence(lambda n: 'foo%d' % n)
 
 
-class SessionActionStandardFactory(SQLAlchemyModelFactory):
+class SessionPersistenceStandardFactory(SQLAlchemyModelFactory):
     class Meta:
         model = models.StandardModel
         sqlalchemy_session = mock.MagicMock()
@@ -113,48 +113,48 @@ class SQLAlchemyPkSequenceTestCase(unittest.TestCase):
 
 
 @unittest.skipIf(sqlalchemy is None, "SQLalchemy not installed.")
-class SQLAlchemySessionActionTestCase(unittest.TestCase):
+class SQLAlchemySessionPersistenceTestCase(unittest.TestCase):
     def setUp(self):
-        super(SQLAlchemySessionActionTestCase, self).setUp()
-        SessionActionStandardFactory.reset_sequence(1)
-        SessionActionStandardFactory._meta.sqlalchemy_session.rollback()
-        SessionActionStandardFactory._meta.sqlalchemy_session.reset_mock()
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = None
+        super(SQLAlchemySessionPersistenceTestCase, self).setUp()
+        SessionPersistenceStandardFactory.reset_sequence(1)
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session.rollback()
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session.reset_mock()
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = None
 
     def test_flush_called(self):
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.flush.called)
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = 'flush'
-        SessionActionStandardFactory.create()
-        self.assertTrue(SessionActionStandardFactory._meta.sqlalchemy_session.flush.called)
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'flush'
+        SessionPersistenceStandardFactory.create()
+        self.assertTrue(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
 
     def test_flush_not_called(self):
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.flush.called)
-        SessionActionStandardFactory.create()
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.flush.called)
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
+        SessionPersistenceStandardFactory.create()
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
 
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = 'commit'
-        SessionActionStandardFactory.create()
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.flush.called)
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'commit'
+        SessionPersistenceStandardFactory.create()
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
 
     def test_commit_called(self):
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.commit.called)
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = 'commit'
-        SessionActionStandardFactory.create()
-        self.assertTrue(SessionActionStandardFactory._meta.sqlalchemy_session.commit.called)
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.commit.called)
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'commit'
+        SessionPersistenceStandardFactory.create()
+        self.assertTrue(SessionPersistenceStandardFactory._meta.sqlalchemy_session.commit.called)
 
     def test_commit_not_called(self):
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.commit.called)
-        SessionActionStandardFactory.create()
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.commit.called)
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.commit.called)
+        SessionPersistenceStandardFactory.create()
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.commit.called)
 
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = 'flush'
-        SessionActionStandardFactory.create()
-        self.assertFalse(SessionActionStandardFactory._meta.sqlalchemy_session.commit.called)
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'flush'
+        SessionPersistenceStandardFactory.create()
+        self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.commit.called)
 
     def test_type_error(self):
-        SessionActionStandardFactory._meta.sqlalchemy_session_action = 'invalid_action'
+        SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'invalid_persistence_option'
         with self.assertRaises(TypeError):
-            SessionActionStandardFactory.create()
+            SessionPersistenceStandardFactory.create()
 
 
 @unittest.skipIf(sqlalchemy is None, "SQLalchemy not installed.")

--- a/tests/test_alchemy.py
+++ b/tests/test_alchemy.py
@@ -24,6 +24,7 @@
 import factory
 from .compat import unittest
 import mock
+import warnings
 
 
 try:
@@ -120,6 +121,7 @@ class SQLAlchemySessionPersistenceTestCase(unittest.TestCase):
         SessionPersistenceStandardFactory._meta.sqlalchemy_session.rollback()
         SessionPersistenceStandardFactory._meta.sqlalchemy_session.reset_mock()
         SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = None
+        SessionPersistenceStandardFactory._meta.force_flush = False
 
     def test_flush_called(self):
         self.assertFalse(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
@@ -155,6 +157,14 @@ class SQLAlchemySessionPersistenceTestCase(unittest.TestCase):
         SessionPersistenceStandardFactory._meta.sqlalchemy_session_persistence = 'invalid_persistence_option'
         with self.assertRaises(TypeError):
             SessionPersistenceStandardFactory.create()
+
+    def test_force_flush_deprecation(self):
+        SessionPersistenceStandardFactory._meta.force_flush = True
+        with warnings.catch_warnings(record=True) as warning_list:
+            SessionPersistenceStandardFactory.create()
+            assert len(warning_list) == 1
+            assert issubclass(warning_list[0].category, DeprecationWarning)
+        self.assertTrue(SessionPersistenceStandardFactory._meta.sqlalchemy_session.flush.called)
 
 
 @unittest.skipIf(sqlalchemy is None, "SQLalchemy not installed.")


### PR DESCRIPTION
Remove `force_flush` and replace with `sqlalchemy_session_action`.  This option takes three values `None`, `'flush'`, or `'commit'`.  If it is set, we preform the indicated action on the session at the end of a `create` call.

Initial discussion can be found here #309 