### PR TITLE
Preserve postgeneration declarations order

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,17 @@
 ChangeLog
 =========
 
+.. _v2.7.1:
+
+2.7.1 (2016-07-10)
+------------------
+
+*New:*
+
+    - :issue:`240`: Call post-generation declarations in the order they were declared,
+      thanks to `Oleg Pidsadnyi <https://github.com/olegpidsadnyi>`_.
+
+
 .. _v2.7.0:
 
 2.7.0 (2016-04-19)

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -1497,6 +1497,9 @@ To support this pattern, factory_boy provides the following tools:
   - :func:`post_generation`: decorator performing the same functions as :class:`PostGeneration`
   - :class:`RelatedFactory`: this builds or creates a given factory *after* building/creating the first Factory.
 
+Post-generation hooks are called in the same order they are declared in the factory class, so that
+functions can rely on the side effects applied by the previous post-generation hook.
+
 
 Extracting parameters
 """""""""""""""""""""

--- a/factory/__init__.py
+++ b/factory/__init__.py
@@ -89,7 +89,7 @@ from . import mogo
 from . import mongoengine
 
 
-__version__ = '2.7.0'
+__version__ = '2.7.1'
 __author__ = 'Raphaël Barrois <raphael.barrois+fboy@polytechnique.org>'
 
 

--- a/factory/base.py
+++ b/factory/base.py
@@ -157,6 +157,14 @@ class FactoryOptions(object):
         self.parameters = {}
         self.parameters_dependencies = {}
 
+    @property
+    def sorted_postgen_declarations(self):
+        """Get sorted postgen declaration items."""
+        return sorted(
+            self.postgen_declarations.items(),
+            key=lambda item: item[1].creation_counter,
+        )
+
     def _build_default_options(self):
         """"Provide the default value for all allowed fields.
 
@@ -516,9 +524,9 @@ class BaseFactory(object):
                 "is either not set or False." % dict(f=cls.__name__))
 
         # Extract declarations used for post-generation
-        postgen_declarations = cls._meta.postgen_declarations
         postgen_attributes = {}
-        for name, decl in sorted(postgen_declarations.items()):
+
+        for name, decl in cls._meta.sorted_postgen_declarations:
             postgen_attributes[name] = decl.extract(name, attrs)
 
         # Generate the object
@@ -526,7 +534,7 @@ class BaseFactory(object):
 
         # Handle post-generation attributes
         results = {}
-        for name, decl in sorted(postgen_declarations.items()):
+        for name, decl in cls._meta.sorted_postgen_declarations:
             extraction_context = postgen_attributes[name]
             results[name] = decl.call(obj, create, extraction_context)
 

--- a/factory/declarations.py
+++ b/factory/declarations.py
@@ -514,6 +514,13 @@ class ExtractionContext(object):
 class PostGenerationDeclaration(object):
     """Declarations to be called once the model object has been generated."""
 
+    creation_counter = 0
+    """Global creation counter of the declaration."""
+
+    def __init__(self, *args, **kwargs):
+        self.creation_counter = PostGenerationDeclaration.creation_counter
+        PostGenerationDeclaration.creation_counter += 1
+
     def extract(self, name, attrs):
         """Extract relevant attributes from a dict.
 


### PR DESCRIPTION
Fixes #240

Basically it keeps track of creation counter of the postgeneration declarations. There's a new property to return them in the sorted order of items.